### PR TITLE
Close the underlying partysocket when an actor stops

### DIFF
--- a/.changeset/tender-trains-talk.md
+++ b/.changeset/tender-trains-talk.md
@@ -1,0 +1,6 @@
+---
+'@statelyai/sky-react': patch
+'@statelyai/sky': patch
+---
+
+Close the underlying partysocket when an actor stops.

--- a/packages/sky-core/src/actorFromStately.ts
+++ b/packages/sky-core/src/actorFromStately.ts
@@ -99,6 +99,8 @@ export async function actorFromStately<T extends AnyStateMachine>(
               event,
             });
           };
+          // Close the socket when the actor stops
+          actor.subscribe({ complete: () => partySocket?.close() });
           resolve(actor);
           break;
         }

--- a/packages/sky-react/package.json
+++ b/packages/sky-react/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "@statelyai/sky": "0.0.8",
     "@xstate/react": "4.0.0-beta.10",
-    "partysocket": "0.0.12",
     "xstate": "5.0.0-beta.37"
   },
   "devDependencies": {

--- a/packages/sky-react/package.json
+++ b/packages/sky-react/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@statelyai/sky": "0.0.8",
     "@xstate/react": "4.0.0-beta.10",
+    "partysocket": "0.0.12",
     "xstate": "5.0.0-beta.37"
   },
   "devDependencies": {

--- a/packages/sky-react/src/useStatelyActor.ts
+++ b/packages/sky-react/src/useStatelyActor.ts
@@ -24,16 +24,14 @@ export function useStatelyActor<T extends AnyStateMachine>(
       fromPromise(() => actorFromStately(options, skyConfig)),
     )
       .start()
-      .subscribe((s) => {
-        s.output?.start();
-        return setMaybeActor(s.output);
-      });
+      .subscribe(({ output }) => setMaybeActor(output));
     return () => {
       return subscription.unsubscribe();
     };
   }, [options.url, options.sessionId, skyConfig]);
 
   useEffect(() => {
+    maybeActor?.start();
     return () => {
       maybeActor?.stop();
     };

--- a/packages/sky-react/src/useStatelyActor.ts
+++ b/packages/sky-react/src/useStatelyActor.ts
@@ -1,6 +1,6 @@
 import { SkyConfigFile, actorFromStately } from '@statelyai/sky';
 import { useSelector } from '@xstate/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { Actor, AnyStateMachine, createActor, fromPromise } from 'xstate';
 
 export function useStatelyActor<T extends AnyStateMachine>(
@@ -13,9 +13,9 @@ export function useStatelyActor<T extends AnyStateMachine>(
     );
   }
 
-  const [maybeActor, setMaybeActor] = useState<Actor<T>>();
+  const actor = useRef<Actor<T>>();
   const state = useSelector(
-    maybeActor ?? createActor(skyConfig.machine),
+    actor.current ?? createActor(skyConfig.machine),
     (snapshot) => snapshot,
   );
 
@@ -25,15 +25,18 @@ export function useStatelyActor<T extends AnyStateMachine>(
     )
       .start()
       .subscribe((s) => {
-        s.output?.start();
-        return setMaybeActor(s.output);
+        actor.current = s.output;
+        actor.current?.start();
       });
-    return () => subscription.unsubscribe();
+    return () => {
+      actor.current?.stop();
+      return subscription.unsubscribe();
+    };
   }, [options.url, options.sessionId, skyConfig]);
 
-  const send = maybeActor?.send;
+  const send = actor.current?.send;
   const isConnecting = send === undefined;
 
   const sky = { isConnecting };
-  return [state, send, maybeActor, sky] as const;
+  return [state, send, actor.current, sky] as const;
 }


### PR DESCRIPTION
This will, for one, help make the participant count numbers more stable.